### PR TITLE
[fix](alert): call handler for the pressed button, regardless its 'role'

### DIFF
--- a/core/src/components/alert/alert.tsx
+++ b/core/src/components/alert/alert.tsx
@@ -461,8 +461,9 @@ export class Alert implements ComponentInterface, OverlayInterface {
 
   private async buttonClick(button: AlertButton) {
     const role = button.role;
+    const hasHandler = button.handler !== undefined;
     const values = this.getValues();
-    if (isCancel(role)) {
+    if (isCancel(role) && hasHandler === false) {
       return this.dismiss({ values }, role);
     }
     const returnData = await this.callButtonHandler(button, values);
@@ -669,9 +670,10 @@ export class Alert implements ComponentInterface, OverlayInterface {
   };
 
   private dispatchCancelHandler = (ev: CustomEvent) => {
-    const role = ev.detail.role;
+    const button = ev.detail;
+    const role = button.role;
     if (isCancel(role)) {
-      const cancelButton = this.processedButtons.find((b) => b.role === 'cancel');
+      const cancelButton = this.processedButtons.find((b) => (b === button && b.role === 'cancel'));
       this.callButtonHandler(cancelButton);
     }
   };

--- a/core/src/components/alert/test/basic/index.html
+++ b/core/src/components/alert/test/basic/index.html
@@ -31,13 +31,13 @@
         <button class="custom-accordion-button" id="basic" onclick="presentAlert()">Alert</button>
         <button id="longMessage" onclick="presentAlertLongMessage()">Alert Long Message</button>
         <button id="multipleButtons" onclick="presentAlertMultipleButtons()">Multiple Buttons (>2)</button>
+        <button id="multipleCancelButtons" onclick="presentAlertMultipleCancelButtons()">Multiple Cancel Buttons (>2)</button>
         <button id="noMessage" onclick="presentAlertNoMessage()">Alert No Message</button>
         <button id="asyncHandler" onclick="presentAlertAsyncHandler()">Alert Async Handler</button>
         <button id="confirm" onclick="presentAlertConfirm()">Confirm</button>
         <button id="prompt" onclick="presentAlertPrompt()">Prompt</button>
         <button id="radio" onclick="presentAlertRadio()">Radio</button>
         <button id="checkbox" onclick="presentAlertCheckbox()">Checkbox</button>
-        <button onclick="presentWithCssClass()">CssClass</button>
       </ion-content>
 
       <style>
@@ -109,6 +109,35 @@
               text: 'Delete',
               id: 'delete-button',
               role: 'destructive',
+            },
+            'Cancel',
+          ],
+        });
+      }
+      
+      function presentAlertMultipleCancelButtons() {
+        openAlert({
+          header: 'Alert',
+          subHeader: 'Subtitle',
+          message: 'This is an alert message.',
+          buttons: [
+            {
+              text: 'Cancel 1',
+              role: 'cancel',
+              handler: () => {
+                console.log('Cancel btn 1');
+              }
+            }, 
+            {
+              text: 'Cancel 2',
+              role: 'cancel',
+              handler: () => {
+                console.log('Cancel btn 2');
+              }
+            },
+            {
+              text: 'Cancel 3',
+              role: 'cancel',
             },
             'Cancel',
           ],

--- a/core/src/components/alert/test/basic/index.html
+++ b/core/src/components/alert/test/basic/index.html
@@ -38,6 +38,7 @@
         <button id="prompt" onclick="presentAlertPrompt()">Prompt</button>
         <button id="radio" onclick="presentAlertRadio()">Radio</button>
         <button id="checkbox" onclick="presentAlertCheckbox()">Checkbox</button>
+        <button onclick="presentWithCssClass()">CssClass</button>
       </ion-content>
 
       <style>


### PR DESCRIPTION
Issue number: resolves https://github.com/ionic-team/ionic-framework/issues/23037

---------

## What is the current behavior?
If two buttons in an alert both have the cancel role, only the first handler will ever be called, regardless of which button is pressed. Changing the roles to be different will result in expected behavior.

## What is the new behavior?
Now the handler for the pressed button is called, regardless of its 'role'.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

> Before the fix:
![WithoutTheFix](https://github.com/joselrio/ionic-framework/assets/5339917/796da981-6531-4a7d-8cac-94adc325d0f9)



> After the fix:
![WithTheFix](https://github.com/joselrio/ionic-framework/assets/5339917/63665a9a-bc2d-42fe-b6ac-3a6bd365f67b)

